### PR TITLE
rootpool/Makefile : support building both x86 and x86_64 versions of the rootpool helper

### DIFF
--- a/rootpool/Makefile
+++ b/rootpool/Makefile
@@ -1,2 +1,8 @@
-all:
-	gcc -Wall -o rootpool rootpool.c -lzfs -lnvpair
+all: i86pc/rootpool amd64/rootpool
+
+i86pc/rootpool: BITS=32
+amd64/rootpool: BITS=64
+
+i86pc/rootpool amd64/rootpool: rootpool.c
+	mkdir -p $(@D)
+	gcc -Wall -m$(BITS) -o $@ $^ -lzfs -lnvpair


### PR DESCRIPTION
Just in case :-)

````
$ make
mkdir -p i86pc
gcc -Wall -m32 -o i86pc/rootpool rootpool.c -lzfs -lnvpair
mkdir -p amd64
gcc -Wall -m64 -o amd64/rootpool rootpool.c -lzfs -lnvpair

$ file */*
amd64/rootpool: ELF 64-bit LSB executable, x86-64, version 1, dynamically linked, interpreter /usr/lib/amd64/ld.so.1, not stripped
i86pc/rootpool: ELF 32-bit LSB executable, Intel 80386, version 1, dynamically linked, interpreter /usr/lib/ld.so.1, not stripped
````